### PR TITLE
Fix JWT_ACCESS_COOKIE_PATH with tenant

### DIFF
--- a/qwc_services_core/jwt.py
+++ b/qwc_services_core/jwt.py
@@ -40,7 +40,10 @@ def jwt_manager(app, api=None):
         # If app.session_interface is a TenantSessionInterface, JWT_ACCESS_COOKIE_PATH is set regarding tenant
         # Else it takes value from SESSION_COOKIE_PATH config var, or APPLICATION_ROOT or /
         # https://flask.palletsprojects.com/en/3.0.x/api/#flask.sessions.SessionInterface.get_cookie_path
-        app.session_interface.get_cookie_path(app)
+        from .tenant_handler import TenantSessionInterface
+        if isinstance(app.session_interface, TenantSessionInterface):
+            if app.session_interface.is_multi():
+                app.session_interface.get_cookie_path(app)
 
     if api:
 

--- a/qwc_services_core/jwt.py
+++ b/qwc_services_core/jwt.py
@@ -35,6 +35,13 @@ def jwt_manager(app, api=None):
 
         return resp
 
+    @app.before_request
+    def set_jwt_access_cookie_path():
+        # If app.session_interface is a TenantSessionInterface, JWT_ACCESS_COOKIE_PATH is set regarding tenant
+        # Else it takes value from SESSION_COOKIE_PATH config var, or APPLICATION_ROOT or /
+        # https://flask.palletsprojects.com/en/3.0.x/api/#flask.sessions.SessionInterface.get_cookie_path
+        app.session_interface.get_cookie_path(app)
+
     if api:
 
         @api.errorhandler

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ Shared modules for QWC services.
 
 setuptools.setup(
     name="qwc-services-core",
-    version="1.3.25",
+    version="1.3.26",
     author="Sourcepole AG",
     author_email="info@sourcepole.ch",
     description="Shared modules for QWC services",


### PR DESCRIPTION
Hi,

This PR should fix #10 

We need to set `JWT_ACCESS_COOKIE_PATH` for the current tenant before each request to know if token has expired and redirect to login page if it is the case.

Thanks for the review

@gwenandres