### PR TITLE
Fix #12: Make tenant_path_prefix consistent by enforcing a slash at the end.

### DIFF
--- a/qwc_services_core/tenant_handler.py
+++ b/qwc_services_core/tenant_handler.py
@@ -202,13 +202,15 @@ class TenantSessionInterface(SecureCookieSessionInterface, TenantHandlerBase):
             'QWC_SERVICE_PREFIX', '').rstrip('/')
 
     def tenant_path_prefix(self):
-        """Tenant path prefix /map/org1 ("$QWC_SERVICE_PREFIX/$TENANT")"""
+        """Tenant path prefix /map/org1/ ("$QWC_SERVICE_PREFIX/$TENANT/")"""
         if self.is_multi():
             return os.environ.get(
                 'TENANT_PATH_PREFIX', '@service_prefix@/@tenant@'
             ).replace(
                 '@service_prefix@', self.service_prefix
-            ).replace('@tenant@', self.tenant())
+            ).replace(
+                '@tenant@', self.tenant()
+            ).rstrip('/') + '/'
         else:
             return self.service_prefix + "/"
 


### PR DESCRIPTION
Fix #12