### PR TITLE
Configure DEFAULT_TENANT with env var

### DIFF
--- a/qwc_services_core/tenant_handler.py
+++ b/qwc_services_core/tenant_handler.py
@@ -8,7 +8,7 @@ from .permissions_reader import PermissionsReader
 from .runtime_config import RuntimeConfig
 
 
-DEFAULT_TENANT = 'default'
+DEFAULT_TENANT = os.environ.get('DEFAULT_TENANT', 'default')
 
 
 class TenantHandlerBase:


### PR DESCRIPTION
Allow to set an other name for `DEFAULT_TENANT` with env var.