### PR TITLE
Strip slashes on tenant prefix

### DIFF
--- a/qwc_services_core/tenant_handler.py
+++ b/qwc_services_core/tenant_handler.py
@@ -186,7 +186,9 @@ class TenantPrefixMiddleware:
                 'TENANT_PATH_PREFIX', '@service_prefix@/@tenant@'
             ).replace(
                 '@service_prefix@', self.service_prefix
-            ).replace('@tenant@', tenant)
+            ).replace(
+                '@tenant@', tenant
+            ).rstrip('/')
             environ['SCRIPT_NAME'] = prefix + environ.get(
                 'SCRIPT_NAME', '')
         return self.app(environ, start_response)


### PR DESCRIPTION
With a setup where the tenant is not part of the path but different tenants are defined for different domains, the urls created by flask contain a double slash after the domain which is introduced by the middleware. This change fixes this behavior by stripping leading slashes.